### PR TITLE
Allow strings in local catids

### DIFF
--- a/indexer/catmap.go
+++ b/indexer/catmap.go
@@ -23,6 +23,7 @@ func (mapping categoryMap) Resolve(cat torznab.Category) []string {
 	var matched bool
 	var results = []string{}
 
+	// check for exact matches
 	for localID, mappedCat := range mapping {
 		if mappedCat.ID == cat.ID {
 			results = append(results, localID)
@@ -30,11 +31,25 @@ func (mapping categoryMap) Resolve(cat torznab.Category) []string {
 		}
 	}
 
+	// check for matches on the parent categories of the mapped categories
+	// e.g asked for Movies, but only had a more specific mapping for Movies/Blu-ray
+	if !matched {
+		for localID, mappedCat := range mapping {
+			if torznab.ParentCategory(mappedCat).ID == cat.ID {
+				results = append(results, localID)
+				matched = true
+			}
+		}
+	}
+
+	// finally check for matches on the parent category of the requested cat
+	// e.g. asked for Movies/Blu-ray but no mapping, so try Movies instead
 	if !matched {
 		parent := torznab.ParentCategory(cat)
 		for localID, mappedCat := range mapping {
 			if mappedCat.ID == parent.ID {
 				results = append(results, localID)
+				matched = true
 			}
 		}
 	}

--- a/indexer/catmap.go
+++ b/indexer/catmap.go
@@ -1,0 +1,53 @@
+package indexer
+
+import "github.com/cardigann/cardigann/torznab"
+
+type categoryMap map[string]torznab.Category
+
+func (mapping categoryMap) Categories() torznab.Categories {
+	cats := torznab.Categories{}
+	added := map[int]bool{}
+
+	for _, c := range mapping {
+		if _, exists := added[c.ID]; exists {
+			continue
+		}
+		cats = append(cats, c)
+		added[c.ID] = true
+	}
+
+	return cats
+}
+
+func (mapping categoryMap) Resolve(cat torznab.Category) []string {
+	var matched bool
+	var results = []string{}
+
+	for localID, mappedCat := range mapping {
+		if mappedCat.ID == cat.ID {
+			results = append(results, localID)
+			matched = true
+		}
+	}
+
+	if !matched {
+		parent := torznab.ParentCategory(cat)
+		for localID, mappedCat := range mapping {
+			if mappedCat.ID == parent.ID {
+				results = append(results, localID)
+			}
+		}
+	}
+
+	return results
+}
+
+func (mapping categoryMap) ResolveAll(cats ...torznab.Category) []string {
+	results := []string{}
+
+	for _, cat := range cats {
+		results = append(results, mapping.Resolve(cat)...)
+	}
+
+	return results
+}

--- a/indexer/catmap_test.go
+++ b/indexer/catmap_test.go
@@ -1,0 +1,41 @@
+package indexer
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cardigann/cardigann/torznab"
+)
+
+func TestCategoryMap(t *testing.T) {
+	cats := categoryMap{
+		"1":   torznab.CategoryTV_Anime,
+		"2":   torznab.CategoryMovies_BluRay,
+		"3":   torznab.CategoryTV_Documentary,
+		"4":   torznab.CategoryTV_Sport,
+		"5":   torznab.CategoryAudio,
+		"6":   torznab.CategoryAudio,
+		"7":   torznab.CategoryMovies,
+		"8":   torznab.CategoryAudio_Video,
+		"10":  torznab.CategoryTV,
+		"12":  torznab.CategoryTV,
+		"xyz": torznab.CategoryAudio_Foreign,
+	}
+
+	for _, test := range []struct {
+		tCats     []torznab.Category
+		localCats []string
+	}{
+		{tCats: []torznab.Category{torznab.CategoryTV_Anime, torznab.CategoryTV_SD}, localCats: []string{"1", "10", "12"}},
+		{tCats: []torznab.Category{torznab.CategoryAudio_Foreign}, localCats: []string{"xyz"}},
+	} {
+		r := cats.ResolveAll(test.tCats...)
+		sort.Sort(sort.StringSlice(r))
+
+		if !reflect.DeepEqual(r, test.localCats) {
+			t.Fatalf("Expected to resolve %#v to %#v, instead got %#v",
+				test.tCats, test.localCats, r)
+		}
+	}
+}

--- a/indexer/catmap_test.go
+++ b/indexer/catmap_test.go
@@ -16,7 +16,7 @@ func TestCategoryMap(t *testing.T) {
 		"4":   torznab.CategoryTV_Sport,
 		"5":   torznab.CategoryAudio,
 		"6":   torznab.CategoryAudio,
-		"7":   torznab.CategoryMovies,
+		"7":   torznab.CategoryMovies_HD,
 		"8":   torznab.CategoryAudio_Video,
 		"10":  torznab.CategoryTV,
 		"12":  torznab.CategoryTV,
@@ -29,6 +29,7 @@ func TestCategoryMap(t *testing.T) {
 	}{
 		{tCats: []torznab.Category{torznab.CategoryTV_Anime, torznab.CategoryTV_SD}, localCats: []string{"1", "10", "12"}},
 		{tCats: []torznab.Category{torznab.CategoryAudio_Foreign}, localCats: []string{"xyz"}},
+		{tCats: []torznab.Category{torznab.CategoryMovies}, localCats: []string{"2", "7"}},
 	} {
 		r := cats.ResolveAll(test.tCats...)
 		sort.Sort(sort.StringSlice(r))

--- a/indexer/filters.go
+++ b/indexer/filters.go
@@ -57,6 +57,17 @@ func invokeFilter(name string, args interface{}, value string) (string, error) {
 		}
 		return filterSplit(sep, pos, value)
 
+	case "replace":
+		from, ok := (args.([]interface{}))[0].(string)
+		if !ok {
+			return "", fmt.Errorf("Filter %q requires a string argument at idx 0", name)
+		}
+		to, ok := (args.([]interface{}))[1].(string)
+		if !ok {
+			return "", fmt.Errorf("Filter %q requires a string argument at idx 1", name)
+		}
+		return strings.Replace(value, from, to, -1), nil
+
 	case "trim":
 		cutset, ok := args.(string)
 		if !ok {

--- a/indexer/parser_test.go
+++ b/indexer/parser_test.go
@@ -3,8 +3,6 @@ package indexer
 import (
 	"reflect"
 	"testing"
-
-	"github.com/cardigann/cardigann/torznab"
 )
 
 const exampleDefinition1 = `
@@ -57,7 +55,7 @@ func TestIndexerParser(t *testing.T) {
 		t.Fatalf("Expected language to get the default, got %q", def.Language)
 	}
 
-	ok, supported := torznab.Capabilities(def.Capabilities).HasSearchMode("tv-search")
+	ok, supported := def.Capabilities.ToTorznab().HasSearchMode("tv-search")
 	if !ok {
 		t.Fatal("Capabilities should support tv-search")
 	}
@@ -66,12 +64,31 @@ func TestIndexerParser(t *testing.T) {
 		t.Fatalf("Supported parameters for tv-search were parsed incorrectly as %v", supported)
 	}
 
-	cat, ok := torznab.Capabilities(def.Capabilities).Categories[6]
-	if !ok {
-		t.Fatalf("Failed to find a mapping for category 6")
+	if l := len(def.Capabilities.ToTorznab().Categories); l != 5 {
+		t.Fatalf("Expected 6 categories, got %d", l)
 	}
+}
 
-	if cat != torznab.CategoryAudio {
-		t.Fatalf("Failed to find a mapping for category 6 to torznab.CategoryAudio")
+const exampleDefinitionWithStringCats = `
+---
+  site: testsite
+  name: Test Site
+  links:
+    - https://www.example.org
+
+  caps:
+    categories:
+      abc:  Movies/BluRay
+      qyz:  Audio
+
+    modes:
+      search: q
+      tv-search: [q, season, ep]
+`
+
+func TestIndexerParserWithStringLocalCats(t *testing.T) {
+	_, err := ParseDefinition([]byte(exampleDefinitionWithStringCats))
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/indexer/runner.go
+++ b/indexer/runner.go
@@ -559,10 +559,14 @@ func (r *Runner) Search(query torznab.Query) ([]torznab.ResultItem, error) {
 
 		if mappedCat, ok := r.Definition.Capabilities.CategoryMap[item.LocalCategoryID]; ok {
 			item.Category = mappedCat.ID
-		} else if intCatId, err := strconv.Atoi(item.LocalCategoryID); err != nil {
-			item.Category = intCatId + torznab.CustomCategoryOffset
 		} else {
-			return nil, fmt.Errorf("Unable to handle category id %q", item.LocalCategoryID)
+			r.Logger.
+				WithFields(logrus.Fields{"localId": item.LocalCategoryID}).
+				Warn("Unknown local category")
+
+			if intCatId, err := strconv.Atoi(item.LocalCategoryID); err == nil {
+				item.Category = intCatId + torznab.CustomCategoryOffset
+			}
 		}
 
 		extracted = append(extracted, item)

--- a/indexer/runner_test.go
+++ b/indexer/runner_test.go
@@ -1,7 +1,6 @@
 package indexer
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -226,7 +225,6 @@ func registerResponder(method, url string, f func(req *http.Request) (*http.Resp
 			return nil, err
 		}
 		resp.Request = innerreq
-		fmt.Printf("%#v", resp)
 		return resp, nil
 	})
 }

--- a/torznab/caps.go
+++ b/torznab/caps.go
@@ -9,7 +9,7 @@ import (
 
 type Capabilities struct {
 	SearchModes []SearchMode
-	Categories  CategoryMapping
+	Categories  Categories
 }
 
 func (c Capabilities) HasSearchMode(key string) (bool, []string) {
@@ -54,7 +54,7 @@ func (c Capabilities) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		})
 	}
 
-	cats := c.Categories.Categories()
+	cats := c.Categories
 	sort.Sort(cats)
 
 	for _, cat := range cats {

--- a/torznab/category.go
+++ b/torznab/category.go
@@ -177,56 +177,6 @@ func ParentCategory(c Category) Category {
 	return CategoryOther
 }
 
-type CategoryMapping map[int]Category
-
-func (mapping CategoryMapping) Categories() Categories {
-	cats := Categories{}
-	added := map[int]bool{}
-
-	for _, c := range mapping {
-		if _, exists := added[c.ID]; exists {
-			continue
-		}
-		cats = append(cats, c)
-		added[c.ID] = true
-	}
-
-	return cats
-}
-
-func (mapping CategoryMapping) Resolve(cat Category) []int {
-	var matched bool
-	var results = []int{}
-
-	for localID, mappedCat := range mapping {
-		if mappedCat.ID == cat.ID {
-			results = append(results, localID)
-			matched = true
-		}
-	}
-
-	if !matched {
-		parent := ParentCategory(cat)
-		for localID, mappedCat := range mapping {
-			if mappedCat.ID == parent.ID {
-				results = append(results, localID)
-			}
-		}
-	}
-
-	return results
-}
-
-func (mapping CategoryMapping) ResolveAll(cats ...Category) []int {
-	results := []int{}
-
-	for _, cat := range cats {
-		results = append(results, mapping.Resolve(cat)...)
-	}
-
-	return results
-}
-
 type Categories []Category
 
 func (slice Categories) Subset(ids ...int) Categories {

--- a/torznab/category.go
+++ b/torznab/category.go
@@ -62,7 +62,7 @@ var (
 	CategoryPC_PhoneAndroid    = Category{4070, "PC/Phone-Android"}
 	CategoryTV                 = Category{5000, "TV"}
 	CategoryTV_WEBDL           = Category{5010, "TV/WEB-DL"}
-	CategoryTV_FOREIGN         = Category{5020, "TV/FOREIGN"}
+	CategoryTV_FOREIGN         = Category{5020, "TV/Foreign"}
 	CategoryTV_SD              = Category{5030, "TV/SD"}
 	CategoryTV_HD              = Category{5040, "TV/HD"}
 	CategoryTV_Other           = Category{5999, "TV/Other"}

--- a/torznab/category_test.go
+++ b/torznab/category_test.go
@@ -2,7 +2,6 @@ package torznab
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 )
 
@@ -28,35 +27,5 @@ func TestCategorySubset(t *testing.T) {
 
 	if !reflect.DeepEqual(s, expected) {
 		t.Fatalf("Expected to resolve to %s, instead got %s", expected, s)
-	}
-}
-
-func TestCategoryMapping(t *testing.T) {
-	cats := CategoryMapping{
-		1:  CategoryTV_Anime,
-		2:  CategoryMovies_BluRay,
-		3:  CategoryTV_Documentary,
-		4:  CategoryTV_Sport,
-		5:  CategoryAudio,
-		6:  CategoryAudio,
-		7:  CategoryMovies,
-		8:  CategoryAudio_Video,
-		10: CategoryTV,
-		12: CategoryTV,
-	}
-
-	for _, test := range []struct {
-		tCats     []Category
-		localCats []int
-	}{
-		{tCats: []Category{CategoryTV_Anime, CategoryTV_SD}, localCats: []int{1, 10, 12}},
-	} {
-		r := cats.ResolveAll(test.tCats...)
-		sort.Sort(sort.IntSlice(r))
-
-		if !reflect.DeepEqual(r, test.localCats) {
-			t.Fatalf("Expected to resolve %#v to %#v, instead got %#v",
-				test.tCats, test.localCats, r)
-		}
 	}
 }


### PR DESCRIPTION
Some trackers have string category id's, this adds support for mapping them back to torznab cats. 