### PR TITLE
Added CinemaZ tracker definition

### DIFF
--- a/definitions/cinemaz.yml
+++ b/definitions/cinemaz.yml
@@ -1,0 +1,55 @@
+---
+  site: cinemaz
+  name: CinemaZ
+  language: en-us
+  links:
+    - https://cinemaz.to/
+
+  caps:
+    categories:
+        "TV-Show Torrent": TV
+        "Movie Torrent": Movies
+        "Music Torrent": Audio
+    modes:
+      search: [q]
+
+  login:
+    path: /auth/login
+    form: form
+    inputs:
+      email_username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+    error:
+      path: /auth/login
+      message:
+        selector: .alert > p:nth-child(2)
+    test:
+      path: /account
+
+  search:
+    path: /torrents
+    inputs:
+       $raw: "search={{ .Query.Keywords }}"
+    rows:
+      selector: table.table:nth-child(3) > tbody:nth-child(2) > tr
+    fields:
+      category:
+        selector: td:nth-child(1) > i:nth-child(1)
+        attribute: title
+      title:
+        selector: td .torrent-file .torrent-filename
+      details:
+        selector: td .torrent-file .torrent-filename
+        attribute: href
+      download:
+        selector: td .torrent-download-icon
+        attribute: href
+      size:
+        selector: td:nth-child(6)
+      date:
+        selector: td:nth-child(4) > span
+        attribute: title
+      seeders:
+        selector: td:nth-child(7)
+      leechers:
+        selector: td:nth-child(8) 


### PR DESCRIPTION
Identical to privatehd so this was fast.

```
Definition file parsing OK
INFO[0000] Testing search mode "search"                 
INFO[0001] Successfully logged in                        site=cinemaz
INFO[0001] Searching indexer                             query=limit=5&t=search site=cinemaz
INFO[0001] Query returned 5 results                      site=cinemaz time=387.634108ms
INFO[0001] Testing downloading torrent                   url=https://cinemaz.to/download/torrent/14056.duffer.1971.720p.bluray.x264.ac.3.7sins.torrent
INFO[0002] Downloaded 13880 bytes from linked torrent   
Indexer test returned OK
```