### PR TITLE
Added AvistaZ tracker definition

### DIFF
--- a/definitions/avistaz.yml
+++ b/definitions/avistaz.yml
@@ -1,0 +1,55 @@
+---
+  site: avistaz
+  name: AvistaZ
+  language: en-us
+  links:
+    - https://avistaz.to/
+
+  caps:
+    categories:
+        "TV-Show Torrent": TV
+        "Movie Torrent": Movies
+        "Music Torrent": Audio
+    modes:
+      search: [q]
+
+  login:
+    path: /auth/login
+    form: form
+    inputs:
+      email_username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+    error:
+      path: /auth/login
+      message:
+        selector: .alert > p:nth-child(2)
+    test:
+      path: /account
+
+  search:
+    path: /torrents
+    inputs:
+       $raw: "search={{ .Query.Keywords }}"
+    rows:
+      selector: table.table:nth-child(3) > tbody:nth-child(2) > tr
+    fields:
+      category:
+        selector: td:nth-child(1) > i:nth-child(1)
+        attribute: title
+      title:
+        selector: td .torrent-file .torrent-filename
+      details:
+        selector: td .torrent-file .torrent-filename
+        attribute: href
+      download:
+        selector: td .torrent-download-icon
+        attribute: href
+      size:
+        selector: td:nth-child(6)
+      date:
+        selector: td:nth-child(4) > span
+        attribute: title
+      seeders:
+        selector: td:nth-child(7)
+      leechers:
+        selector: td:nth-child(8) 


### PR DESCRIPTION
Identical to privatehd and cinemaz so this was fast.
```
Definition file parsing OK
INFO[0000] Testing search mode "search"                 
INFO[0002] Successfully logged in                        site=avistaz
INFO[0002] Searching indexer                             query=limit=5&t=search site=avistaz
INFO[0002] Query returned 5 results                      site=avistaz time=342.475683ms
INFO[0002] Testing downloading torrent                   url=https://avistaz.to/download/torrent/52276.the.wailing.goksung.2016.limited.720p.bluray.x264.depth.torrent
INFO[0003] Downloaded 39458 bytes from linked torrent   
Indexer test returned OK
```