### PR TITLE
Fix alpharatio definition (round 2)

### DIFF
--- a/definitions/alpharatio.yml
+++ b/definitions/alpharatio.yml
@@ -55,7 +55,7 @@
   search:
     path: /torrents.php
     inputs:
-       $raw: "{{range .Categories}}filter_cat[]={{.}}&{{end}}searchstr={{ .Query.Keywords }}"
+       $raw: "searchsubmit=1&{{range .Categories}}filter_cat[]={{.}}&{{end}}searchstr={{ .Query.Keywords }}"
     rows:
       selector: table#torrent_table tr.torrent
     fields:
@@ -74,12 +74,11 @@
         selector: td.big_info span a:nth-child(1)
         attribute: href
       size:
-        selector: td:nth-child(6)
+        selector: td:nth-child(5)
       date:
-        selector: td:nth-child(5) .time
+        selector: td:nth-child(4) .time
         attribute: title
       seeders:
-        selector: td:nth-child(8)
+        selector: td:nth-child(7)
       leechers:
-        selector: td:nth-child(9)
-
+        selector: td:nth-child(8)


### PR DESCRIPTION
Fixes #62 

Prepends `searchsubmit=1` to ensure the same output regardless of default filter settings.

Test output:

```
./cardigann test definitions/alpharatio.yml 
→ Testing 1 definition(s) (dev/linux/amd64)
→ Testing indexer alpharatio at https://alpharatio.cc/
  Testing login with valid credentials SUCCESS ✓ in 2.412593683s
  Testing search mode "search" SUCCESS ✓ in 3.612463663s
  Testing search mode "tv-search" SUCCESS ✓ in 3.274425608s
  Testing empty results are handled SUCCESS ✓ in 805.457642ms
  Testing ratio SUCCESS ✓ in 810.51563ms
→ Indexer alpharatio is OK
```