### PR TITLE
Added sceneaccess tracker definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Norbits
 * PrivateHD
 * Speed.CD
+* Sceneaccess
 * ThePirateBay (TPB)
 * Torrentbytes
 * TorrentDay

--- a/definitions/sceneaccess.yml
+++ b/definitions/sceneaccess.yml
@@ -1,0 +1,101 @@
+---
+  site: sceneaccess
+  name: sceneaccess
+  language: en-us
+  links:
+    - https://sceneaccess.eu/
+
+  caps:
+    categories:
+        8:  Movies/SD  #Movies/DVD-R
+        22:  Movies #Movies/x264
+        7:  Movies #Movies/Xvid
+        4:  Movies #Movies/Packs
+        17:  TV/SD  #TV/SD-x264
+        27:  TV/HD  #TV/HD-x264
+        11:  TV  #TV/Xvid
+        26:  TV  #TV/Packs
+        3:   PC/Games # Games/PC
+        5: Console/PS3 #Games/PS3
+        20: Console/PSP  #Games/PSP
+        28: Console/Wii  #Games/Wii
+        23: Console/Xbox360 #Games/Xbox360
+        29:  PC/Games # Games/Packs
+        29:  Console # Games/Packs
+        29:  PC/Mac # Games/Packs
+        40:  Audio/Lossless #Music/Flac
+        13:  Audio/MP3      #Music/MP3
+        15:  Audio/Video # Music/MVID
+        38:  Audio       #Music/Packs
+        1:   PC/ISO # Apps/ISO
+        2:   PC/0day # Apps/0DAY
+        14:  Other/Misc #DOX
+        21:  Other/Misc #Misc
+        41:  Movies/HD #P2P/Movies/HD-x264
+        42:  Movies/SD #P2P/Movies/SD-x264
+        43:  Movies/SD  #P2P/Movies/Xvid
+        44:  TV/SD  #P2P/TV/SD
+        45:  TV/HD  #P2P/TV/HD
+        34:  TV/HD
+        36:  XXX  #XXX/0DAY
+        37:  XXX  #XXX/Packs
+        35:  XXX/x264
+        12:  XXX/XviD
+        31:  Movies/Foreign #Foreign Movies/DVD-R
+        32:  Movies/Foreign #Foreign Movies/x264
+        30:  Movies/Foreign #Foreign Movies/XviD
+        34:  TV/Foreign #Foreign TV/x264
+        33:  TV/Foreign #Foreign TV/XviD
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: /login
+    method: form
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+    error:
+      message:
+        selector: #login_box_desc
+    test:
+      path: /inbox
+
+  search:
+    path: /all
+    inputs:
+       $raw: "search={{ .Query.Keywords }}&method=2"
+    rows:
+      selector: tr.tt_row
+    fields:
+      category:
+        selector: td.ttr_type a[href^="?cat="]
+        attribute: href
+        filters:
+          - name: regexp
+            args: "\\?cat=(\\d+)"
+      title:
+        selector: td.ttr_name a
+        attribute: title
+      details:
+        selector: td.ttr_name a
+        attribute: href
+      comments:
+        selector: td.ttr_name a
+        attribute: href
+      download:
+        selector: td.td_dl a
+        attribute: href
+      size:
+        selector: td.ttr_size
+        filters:
+          - name: regexp
+            args: "(\\d*.\\d*\\s..).*"
+      date:
+        selector: td.ttr_added
+      seeders:
+        selector: td.ttr_seeders
+      leechers:
+        selector: td.ttr_leechers

--- a/definitions/sceneaccess.yml
+++ b/definitions/sceneaccess.yml
@@ -59,7 +59,7 @@
       password: "{{ .Config.password }}"
     error:
       message:
-        selector: #login_box_desc
+        selector: "#login_box_desc"
     test:
       path: /inbox
 


### PR DESCRIPTION

- [x] Run `cardigann test definitions/trackername.yml` and include the output here:

```
→ Testing 1 definition(s) (1.8.5-18-g8437de7/linux/amd64)
→ Testing indexer sceneaccess at https://sceneaccess.eu/
  Testing login with valid credentials SUCCESS ✓ in 8.102449596s
  Testing search mode "search" SUCCESS ✓ in 56.734658192s
  Testing search mode "tv-search" SUCCESS ✓ in 6.880802031s
  Testing empty results are handled SUCCESS ✓ in 4.557961252s
  Testing ratio SUCCESS ✓ in 19.277µs
→ Indexer sceneaccess is OK

``` 

- [x] Post the version of cardigann you tested this with (from the footer of the web interface or `cardigann --version`)

1.8.5-18-g8437de7
- [x] Make sure to add the indexer to the list in the README
