### PR TITLE
Add Torrent-Syndikat tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Speed.CD
 * Sceneaccess
 * ThePirateBay (TPB)
+* Torrent-Syndikat
 * Torrentbytes
 * TorrentDay
 * Torrentleech

--- a/definitions/torrentsyndikat.yml
+++ b/definitions/torrentsyndikat.yml
@@ -1,0 +1,112 @@
+---
+  site: torrentsyndikat
+  name: Torrent-Syndikat
+  description: "A German general tracker"
+  language: de-de
+  links:
+    - https://torrent-syndikat.org/
+
+  caps:
+    categories:
+      2:  PC # Apps / Windows
+      13: PC # Apps / Linux
+      4:  PC/Mac # Apps / Mac
+      6:  PC # Apps / Misc
+      12: PC/Games # Spiele / PC
+      8:  Console/PSP # Spiele / PSX/PSP
+      7:  Console/Wii # Spiele / Wii
+      32: Console/Xbox # Spiele / XBOX
+      41: Console/NDS # Spiele / Nintendo DS
+      22: Movies/3D # Filme / 3D
+      3:  Movies/BluRay # Filme / BluRay
+      11: Movies/Other # Filme / REMUX
+      42: Movies/HD # Filme / 2160p
+      9:  Movies/HD # Filme / 1080p
+      20: Movies/HD # Filme / 720p
+      21: Movies/DVD # Filme / DVD
+      10: Movies/SD # Filme / SD
+      31: Movies/Other # Filme / Anime
+      37: Movies/Foreign # Filme / Englisch
+      16: TV/HD # TV / Serien/HD
+      15: TV/SD # TV / Serien/SD
+      44: TV/HD # TV / Packs/UHD
+      23: TV/HD # TV / Packs/HD
+      27: TV/SD # TV / Packs/SD
+      28: TV/Documentary # TV / Dokus/SD
+      29: TV/Documentary # TV / Dokus/HD
+      30: TV/Sport # TV / Sport
+      40: TV/Anime # TV / Anime
+      36: TV/Foreign # TV / Englisch
+      24: Audio/Lossless # Audio / FLAC
+      25: Audio/MP3 # Audio / MP3
+      35: Audio/Other # Audio / Other
+      26: Audio # Audio / Packs
+      18: Audio/Audiobook # Audio / aBooks
+      33: Audio/Video # Audio / Videos
+      17: Books # Misc / eBooks
+      5:  PC/Phone-Other # Misc / Mobile
+      39: Other # Misc / Bildung
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  settings:
+    - name: cookie
+      type: text
+      label: Cookie
+
+  login:
+    method: cookie
+    inputs:
+      cookie: "{{ .Config.cookie }}"
+    test:
+      path: /ucp.php?action=default
+
+  ratio:
+    path: /browse.php
+    selector: i[title="Gesamtratio"] ~ span
+
+  search:
+    path: /browse.php?do=search
+    inputs:
+      $raw: "{{range .Categories}}cat[]={{.}}&{{end}}"
+      search: "{{ .Query.Keywords }}"
+      searchin: title
+      incldead: 1
+      rel_type: 0
+
+    rows:
+      selector: table.torrent_table > tbody > tr:not(:has(td.colhead))
+    fields:
+      title:
+        selector: a[title][href^="details.php"]
+        attribute: title
+      category:
+        selector: a[href^="browse.php?cat="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: cat
+      comments:
+        selector: a[title][href^="details.php"]
+        attribute: href
+      download:
+        selector: a[href^="download.php"]
+        attribute: href
+      size:
+        selector: td:nth-child(6)
+      seeders:
+        selector: td:nth-child(8)
+      leechers:
+        selector: td:nth-child(9)
+      date:
+        selector: span.torrent_details
+        remove: i, a
+        filters:
+          - name: replace
+            args: ["Heute", "Today"]
+          - name: replace
+            args: ["Gestern", "Yesterday"]
+          - name: replace
+            args: [" von", ""]


### PR DESCRIPTION
Fixes #127

For a new indexer, please follow this checklist:

- [X] Run `cardigann test definitions/trackername.yml` and include the output here:

```
→ Testing 1 definition(s) (1.8.7-43-g72447b0/windows/amd64)
→ Testing indexer torrentsyndikat at https://torrent-syndikat.org/
  Testing required config is available ←[32mSUCCESS V←[0m ←[37min 0s←[0m
  Testing login with valid credentials ←[32mSUCCESS V←[0m ←[37min 304.0387ms←[0m
  Testing search mode "search" ←[32mSUCCESS V←[0m ←[37min 2.9088694s←[0m
  Testing search mode "tv-search" ←[32mSUCCESS V←[0m ←[37min 709.5901ms←[0m
  Testing empty results are handled ←[32mSUCCESS V←[0m ←[37min 729.0926ms←[0m
  Testing ratio ←[32mSUCCESS V←[0m ←[37min 760.5966ms←[0m
→ Indexer torrentsyndikat is ←[32mOK←[0m
``` 

- [X] Make sure to add the indexer to the list in the README