### PR TITLE
Add SceneTime tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * PrivateHD
 * Speed.CD
 * Sceneaccess
+* SceneTime
 * ThePirateBay (TPB)
 * Torrentbytes
 * TorrentDay

--- a/definitions/scenetime.yml
+++ b/definitions/scenetime.yml
@@ -1,0 +1,105 @@
+---
+  site: scenetime
+  name: SceneTime
+  description: "A general tracker"
+  language: en-us
+  links:
+    - https://www.scenetime.com/
+
+  caps:
+    categories:
+      1: Movies/SD
+      3: Movies/DVD
+      47: Movies/SD
+      57: Movies/SD
+      59: Movies/HD
+      61: Movies/SD
+      64: Movies/3D
+      80: Movies/Foreign
+      81: Movies/BluRay
+      82: Movies/Other
+      102: Movies/Other
+      103: Movies/WEBDL
+      105: Movies
+      6: PC/Games
+      48: Console/Xbox
+      49: Console/PSP
+      50: Console/PS3
+      51: Console/Wii
+      55: Console/NDS
+      107: Console/PS4
+      2: TV/SD
+      43: TV
+      9: TV/HD
+      63: TV
+      77: TV/SD
+      79: TV/Sport
+      100: TV/Foreign
+      83: TV/WEB-DL
+      5: PC/0day
+      7: Books
+      52: PC/Mac
+      65: Books/Comics
+      53: PC
+      4: Audio
+      11: Audio/Video
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  settings:
+    - name: cookie
+      type: text
+      label: Cookie
+
+  login:
+    method: cookie
+    inputs:
+      cookie: "{{ .Config.cookie }}"
+    test:
+      path: /my.php
+
+  ratio:
+    path: /my.php
+    selector: div#Statusdiv > div.FLl > font:nth-child(3)
+
+  search:
+    path: /browse.php?do=search
+    inputs:
+      $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
+      search: "{{ .Query.Keywords }}"
+      cata: yes
+      sec: jax
+
+    rows:
+      selector: tr.browse
+    fields:
+      title:
+        selector: a[href^="details.php"] > font > b
+      category:
+        selector: a[href^="browse.php?cat="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: cat
+      comments:
+        selector: a[href^="details.php"]
+        attribute: href
+      download:
+        selector: a[href^="details.php"]
+        attribute: href
+        filters:
+          - name: replace
+            args: ["details.php?id=", "download.php/"]
+          - name: append
+            args: "/dummy.torrent"
+      size:
+        selector: td:nth-child(4)
+      seeders:
+        selector: td:nth-child(5)
+      leechers:
+        selector: td:nth-child(6)
+      date:
+        selector: span.elapsedDate
+        attribute: title


### PR DESCRIPTION
fixes #125

For a new indexer, please follow this checklist:

- [x] Run `cardigann test definitions/trackername.yml` and include the output here:

```
→ Testing 1 definition(s) (1.8.7-43-g72447b0/windows/amd64)
→ Testing indexer scenetime at https://www.scenetime.com/
  Testing required config is available ←[32mSUCCESS V←[0m ←[37min 0s←[0m
  Testing login with valid credentials ←[32mSUCCESS V←[0m ←[37min 287.5365ms←[0m
  Testing search mode "search" ←[32mSUCCESS V←[0m ←[37min 400.0508ms←[0m
  Testing search mode "tv-search" ←[32mSUCCESS V←[0m ←[37min 615.5781ms←[0m
  Testing empty results are handled ←[32mSUCCESS V←[0m ←[37min 146.0185ms←[0m
  Testing ratio ←[32mSUCCESS V←[0m ←[37min 100.0127ms←[0m
→ Indexer scenetime is ←[32mOK←[0m
``` 

- [x] Make sure to add the indexer to the list in the README

