### PR TITLE
add FunFile tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * EZTV
 * FileList
 * Freshon
+* FunFile
 * HD-Torrents
 * HDArea
 * HDME

--- a/definitions/funfile.yml
+++ b/definitions/funfile.yml
@@ -1,0 +1,79 @@
+---
+  site: funfile
+  name: FunFile
+  description: "A general tracker"
+  language: en-us
+  links:
+    - https://www.funfile.org/
+
+  caps:
+    categories:
+      44: TV/Anime # Anime
+      22: PC # Applications
+      43: Audio/Audiobook # Audio Books
+      27: Books # Ebook
+      4:  PC/Games # Games
+      40: Other/Misc # Miscellaneous
+      19: Movies # Movies
+      6:  Audio # Music
+      31: PC/Phone-Other # Portable
+      7:  TV # TV
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: /takelogin.php
+    method: post
+    form: form
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+      login: "Login"
+    error:
+      - selector: mf_content
+    test:
+      path: /my.php
+
+  ratio:
+    path: /browse.php
+    selector: div:has(div#clock) > b:last-child
+
+  search:
+    path: /browse.php
+    inputs:
+      $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
+      search: "{{ .Query.Keywords }}"
+      incldead: 1
+      showspam: 1
+
+    rows:
+      selector: table[cellpadding="2"] > tbody > tr:has(td.row3)
+    fields:
+      title:
+        selector: a[title][href^="details.php"]
+        attribute: title
+      category:
+        selector: a[href^="browse.php?cat="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: cat
+      comments:
+        selector: a[href^="details.php?id="]
+        attribute: href
+      download:
+        selector: a[href^="download.php"]
+        attribute: href
+      size:
+        selector: td:nth-child(8)
+      seeders:
+        selector: td:nth-child(10)
+      leechers:
+        selector: td:nth-child(11)
+      date:
+        selector: td:nth-child(6)
+        filters:
+          - name: append
+            args: " ago"


### PR DESCRIPTION
fixes #150

For a new indexer, please follow this checklist:

- [X] Run `cardigann test definitions/trackername.yml` and include the output here:

```
→ Testing 1 definition(s) (1.9.2/windows/amd64)
→ Testing indexer funfile at https://www.funfile.org/
  Testing required config is available SUCCESS V in 500.1µs
  Testing login with valid credentials SUCCESS V in 5.2941723s
  Testing search mode "search" SUCCESS V in 20.0840503s
  Testing search mode "tv-search" SUCCESS V in 17.8022606s
  Testing empty results are handled SUCCESS V in 5.6127127s
  Testing ratio SUCCESS V in 5.9857601s
→ Indexer funfile is OK
``` 

- [X] Make sure to add the indexer to the list in the README

If you run into issues with testing, remember you can run a debug test with `cardigann test --debug --cachepages definitions/trackername.yml`. 

