### PR TITLE
Add missing torznab attributes files, grabs, downloadvolumefactor, uploadvolumefactor

### DIFF
--- a/definitions/iptorrents.yml
+++ b/definitions/iptorrents.yml
@@ -112,3 +112,11 @@
         selector: td:nth-child(8)
       leechers:
         selector: td:nth-child(9)
+      grabs:
+        selector: td:nth-child(7)
+      downloadvolumefactor:
+        case:
+          span.t_tag_free_leech: "0"
+          "*": "1"
+      uploadvolumefactor:
+        text: "1"

--- a/definitions/morethantv.yml
+++ b/definitions/morethantv.yml
@@ -60,3 +60,11 @@
         selector: td:nth-child(8)
       leechers:
         selector: td:nth-child(9)
+      files:
+        selector: td:nth-child(4)
+      grabs:
+        selector: td:nth-child(7)
+      downloadvolumefactor:
+        text: "0"
+      uploadvolumefactor:
+        text: "1"

--- a/indexer/runner.go
+++ b/indexer/runner.go
@@ -935,6 +935,34 @@ func (r *Runner) extractItem(rowIdx int, selection *goquery.Selection) (extracte
 				continue
 			}
 			item.PublishDate = t
+		case "files":
+			files, err := strconv.Atoi(normalizeNumber(val))
+			if err != nil {
+				r.logger.Warnf("Row #%d has unparseable files value %q in %s", rowIdx, val, key)
+				continue
+			}
+			item.Files = files
+		case "grabs":
+			grabs, err := strconv.Atoi(normalizeNumber(val))
+			if err != nil {
+				r.logger.Warnf("Row #%d has unparseable grabs value %q in %s", rowIdx, val, key)
+				continue
+			}
+			item.Grabs = grabs
+		case "downloadvolumefactor":
+			downloadvolumefactor, err := strconv.ParseFloat(normalizeNumber(val), 64)
+			if err != nil {
+				r.logger.Warnf("Row #%d has unparseable downloadvolumefactor value %q in %s", rowIdx, val, key)
+				continue
+			}
+			item.DownloadVolumeFactor = downloadvolumefactor
+		case "uploadvolumefactor":
+			uploadvolumefactor, err := strconv.ParseFloat(normalizeNumber(val), 64)
+			if err != nil {
+				r.logger.Warnf("Row #%d has unparseable uploadvolumefactor value %q in %s", rowIdx, val, key)
+				continue
+			}
+			item.UploadVolumeFactor = uploadvolumefactor
 		default:
 			r.logger.Warnf("Row #%d has unknown field %s", rowIdx, key)
 			continue

--- a/indexer/selector.go
+++ b/indexer/selector.go
@@ -53,7 +53,7 @@ func (s *selectorBlock) Text(el *goquery.Selection) (string, error) {
 			WithFields(logrus.Fields{"case": s.Case}).
 			Debugf("Applying case to selection")
 		for pattern, value := range s.Case {
-			if el.Is(pattern) {
+			if el.Has(pattern).Length() >= 1 {
 				return s.applyFilters(value)
 			}
 		}

--- a/indexer/selector.go
+++ b/indexer/selector.go
@@ -56,7 +56,7 @@ func (s *selectorBlock) Text(el *goquery.Selection) (string, error) {
 			WithFields(logrus.Fields{"case": s.Case}).
 			Debugf("Applying case to selection")
 		for pattern, value := range s.Case {
-			if el.Has(pattern).Length() >= 1 {
+			if el.Is(pattern) || el.Has(pattern).Length() >= 1 {
 				return s.applyFilters(value)
 			}
 		}

--- a/indexer/selector.go
+++ b/indexer/selector.go
@@ -29,6 +29,9 @@ func (s *selectorBlock) Match(selection *goquery.Selection) bool {
 }
 
 func (s *selectorBlock) MatchText(from *goquery.Selection) (string, error) {
+	if s.TextVal != "" {
+		return s.TextVal, nil
+	}
 	if s.Selector != "" {
 		result := from.Find(s.Selector)
 		if result.Length() == 0 {

--- a/torznab/result.go
+++ b/torznab/result.go
@@ -18,12 +18,16 @@ type ResultItem struct {
 	Link        string
 	Category    int
 	Size        uint64
+	Files       int
+	Grabs       int
 	PublishDate time.Time
 
 	Seeders         int
 	Peers           int
 	MinimumRatio    float64
 	MinimumSeedTime time.Duration
+	DownloadVolumeFactor    float64
+	UploadVolumeFactor      float64
 }
 
 func (ri ResultItem) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -47,6 +51,8 @@ func (ri ResultItem) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		Comments    string      `xml:"comments,omitempty"`
 		Link        string      `xml:"link,omitempty"`
 		Category    string      `xml:"category,omitempty"`
+		Files       int         `xml:"files,omitempty"`
+		Grabs       int         `xml:"grabs,omitempty"`
 		PublishDate string      `xml:"pubDate,omitempty"`
 		Enclosure   interface{} `xml:"enclosure,omitempty"`
 
@@ -59,6 +65,8 @@ func (ri ResultItem) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		Comments:    ri.Comments,
 		Link:        ri.Link,
 		Category:    strconv.Itoa(ri.Category),
+		Files:       ri.Files,
+		Grabs:       ri.Grabs,
 		PublishDate: ri.PublishDate.Format(rfc822),
 		Enclosure:   enclosure,
 		Attrs: []torznabAttrView{
@@ -68,6 +76,8 @@ func (ri ResultItem) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 			{Name: "minimumratio", Value: fmt.Sprintf("%.f", ri.MinimumRatio)},
 			{Name: "minimumseedtime", Value: fmt.Sprintf("%.f", ri.MinimumSeedTime.Seconds())},
 			{Name: "size", Value: fmt.Sprintf("%d", ri.Size)},
+			{Name: "downloadvolumefactor", Value: fmt.Sprintf("%.f", ri.DownloadVolumeFactor)},
+			{Name: "uploadvolumefactor", Value: fmt.Sprintf("%.f", ri.UploadVolumeFactor)},
 		},
 	}
 


### PR DESCRIPTION
files: Number of files
grabs: Number of times item downloaded
downloadvolumefactor: factor for the download volume, in most cases it should be set to 1, if a torrent is set to freeleech set it to 0, if only 50% is counted set it to 0.5
uploadvolumefactor: factor for the upload volume, in most cases it should be set to 1, if a torrent is set to neutral leech (upload is not counted) set it to 0, if it's set to double upload set it to 2

Besides the attributes the behavior of "case" has been slightly modified:
The pattern doesn't need to be an exact match any longer.
This makes writing cases for downloadvolumefactor/uploadvolumefactor easier