### PR TITLE
Add WorldOfP2P tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cardigann server
 
 Once the server is running, visit http://localhost:5060 and configure via the web interface.
 
-You can set a password requirement by either passing the `--passphrase` flag to the server command, or by setting `global.password` in the [Configuration](#Configuration).
+You can set a password requirement by either passing the `--passphrase` flag to the server command, or by setting `global.passphrase` in the [Configuration](#Configuration).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cardigann server
 
 Once the server is running, visit http://localhost:5060 and configure via the web interface.
 
-You can set a password requirement by either passing the `--passphrase` flag to the server command, or by setting `global.passphrase` in the [Configuration](#Configuration).
+You can set a password requirement by either passing the `--passphrase` flag to the server command, or by setting `global.password` in the [Configuration](#Configuration).
 
 ## Installation
 
@@ -147,13 +147,12 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Speed.CD
 * Sceneaccess
 * SceneTime
-* Shareisland
 * ThePirateBay (TPB)
 * Torrent-Syndikat
 * Torrentbytes
 * TorrentDay
 * Torrentleech
-* Transmithe.Net
+* WorldOfP2P
 
 I'm happy to add new trackers, please either open a new issue, or a pull request with whatever details you have for the tracker.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Speed.CD
 * Sceneaccess
 * SceneTime
+* Shareisland
 * ThePirateBay (TPB)
 * Torrent-Syndikat
 * Torrentbytes

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Torrentbytes
 * TorrentDay
 * Torrentleech
+* Transmithe.Net
 
 I'm happy to add new trackers, please either open a new issue, or a pull request with whatever details you have for the tracker.
 

--- a/definitions/bitmetv.yml
+++ b/definitions/bitmetv.yml
@@ -27,7 +27,7 @@
 
   ratio:
     path: https://www.bitmetv.org/browse.php
-    selector: span.smallfont > font[color="#000000"]
+    selector: span.smallfont > font[color="1900D1"] + font
 
   search:
     path: https://www.bitmetv.org/browse.php
@@ -63,3 +63,15 @@
         selector: td:nth-child(9)
       leechers:
         selector: td:nth-child(10)
+      files:
+        selector: td:nth-child(4)
+      grabs:
+        selector: td:nth-child(8)
+        filters:
+          - name: regexp
+            args: "(\\d+)"
+      downloadvolumefactor:
+        case:
+          "*": "1"
+      uploadvolumefactor:
+        text: "1"

--- a/definitions/funfile.yml
+++ b/definitions/funfile.yml
@@ -38,7 +38,7 @@
 
   ratio:
     path: /browse.php
-    selector: div:has(div#clock) > b:last-child
+    selector: div:has(div#clock) > b + b+ b > span
 
   search:
     path: /browse.php

--- a/definitions/hdspace.yml
+++ b/definitions/hdspace.yml
@@ -49,6 +49,7 @@
       pwd: "{{ .Config.password }}"
     test:
       path: /index.php?page=torrents
+      selector: div#menu
 
   search:
     path: /index.php?page=torrents&active=0&options=0&category=15%3B40

--- a/definitions/scenetime.yml
+++ b/definitions/scenetime.yml
@@ -95,11 +95,18 @@
           - name: append
             args: "/dummy.torrent"
       size:
-        selector: td:nth-child(4)
-      seeders:
-        selector: td:nth-child(5)
-      leechers:
         selector: td:nth-child(6)
+      seeders:
+        selector: td:nth-child(7)
+      leechers:
+        selector: td:nth-child(8)
       date:
         selector: span.elapsedDate
         attribute: title
+      downloadvolumefactor:
+        case:
+          "font > b:contains(\"Freeleech\")": "0"
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "*": "1"

--- a/definitions/shareisland.yml
+++ b/definitions/shareisland.yml
@@ -1,0 +1,150 @@
+﻿---
+  site: shareisland
+  name: Shareisland
+  description: "A general italian tracker"
+  language: it-it
+  links:
+    - http://shareisland.org
+
+  caps:
+    categories:
+       32: Other # Vip
+       45: XXX # Vip XXX
+       33: Other # ex Vip
+       1: Movies # Movies
+       49: Movies/HD # H-264
+       51: Movies/HD # H-265
+       41: Movies/Other # Cartoons
+       14: Movies/SD # DivX
+       16: Movies/Other # Cine News
+       39: Movies/HD # 720p
+       40: Movies/HD # 1080p
+       46: Movies/BluRay # Blu Ray Disk
+       31: Movies/HD # BDRip
+       17: Movies/DVD # DVD
+       43: Movies/SD # DVDRip
+       6: PC # Applications
+       18: PC/0day # PC Applications
+       19: PC/Mac # Macintosh Applications
+       44: PC/Phone-Android # Android applications
+       7: Audio # Music
+       20: Audio/Video # Video
+       21: Audio/MP3 # Mp3
+       2: Console # Games
+       3: Console/PS4 # Sony PS
+       4: Console/Wii # Wii
+       26: Console/Xbox # XboX
+       27: PC/Games # PC
+       28: Console/NDS # Nintendo
+       34: Books # Edicola
+       52: Books # Quotidiani
+       53: Books # Libreria
+       35: TV # SerieTV
+       55: TV/HD # Serie Tv HD
+       36: Other # Rip By ShareIsland
+       47: Other # Disclaimer
+       48: Other # P2P network 
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: /ajax/login.php
+    method: post
+    form: form
+    inputs:
+      loginbox_membername: "{{ .Config.username }}"
+      loginbox_password: "{{ .Config.password }}"
+      action: "login"
+      loginbox_remember: "true"
+    error:
+      - selector: div.error
+    test:
+      path: /?p=home&pid=1
+      selector: div#member_info_bar
+
+  ratio:
+    path: /?p=home&pid=1
+    selector: img[title="Ratio"] + span
+
+  search:
+    path: /
+    inputs:
+      p: "torrents"
+      pid: "32"
+      $raw: "{{range .Categories}}cid[]:{{.}}&{{end}}"
+      keywords: "{{ .Query.Keywords }}"
+      search_type: "name"
+      searchin: "title"
+
+    rows:
+      selector: table#torrents_table_classic > tbody > tr:not([id="torrents_table_classic_head"])
+    fields:
+      title:
+        selector: td.torrent_name > a
+      category:
+        selector: div.category_image > a
+        attribute: href
+        filters:
+          - name: querystring
+            args: cid
+      comments:
+        selector: td.torrent_name > a
+        attribute: href
+      download:
+        selector: a:has(img[title="Download Torrent"])
+        attribute: href
+      size:
+        selector: td.size
+      seeders:
+        selector: td.seeders
+      leechers:
+        selector: td.leechers
+      grabs:
+        selector: td.completed
+      downloadvolumefactor:
+        case:
+          "img[title=\"FREE!\"]": "0"
+          "img[title=\"Download Multiplier: 0.5\"]": "0.5"
+          "img[title=\"Moltiplicatore Download: 0.5\"]": "0.5"
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "img[title=\"Upload Multiplier: 3\"]": "3"
+          "img[title=\"Upload Multiplier: 2\"]": "2"
+          "img[title=\"Upload Multiplier: 1.5\"]": "1.5"
+          "img[title=\"Moltiplicatore Upload: 3\"]": "3"
+          "img[title=\"Moltiplicatore Upload: 2\"]": "2"
+          "img[title=\"Moltiplicatore Upload: 1.5\"]": "1.5"
+          "*": "1"
+      date:
+        selector: td.torrent_name
+        remove: a, span, div, br
+        filters:
+          - name: replace
+            args: ["Uploaded ", ""]
+          - name: replace
+            args: [" by", ""]
+          - name: replace
+            args: [" at", ""]
+          - name: replace
+            args: ["Oggi", "Today"]
+          - name: replace
+            args: ["Ieri", "Yesterday"]
+          - name: replace
+            args: ["lunedì", "Monday"]
+          - name: replace
+            args: ["martedì", "Tuesday"]
+          - name: replace
+            args: ["Mercoledì", "Wednesday"]
+          - name: replace
+            args: ["Giovedì", "Thursday"]
+          - name: replace
+            args: ["Venerdì", "Friday"]
+          - name: replace
+            args: ["Sabato", "Saturday"]
+          - name: replace
+            args: ["Domenica", "Sunday"]
+          - name: replace
+            args: [" alle", ""]

--- a/definitions/transmithenet.yml
+++ b/definitions/transmithenet.yml
@@ -1,0 +1,98 @@
+﻿---
+  site: transmithenet
+  name: Transmithe.net
+  description: "A TV tracker"
+  language: en-us
+  links:
+    - https://transmithe.net
+
+  caps:
+    categories:
+      1: TV
+      2: TV/HD
+      3: TV/SD
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: /login.php
+    method: post
+    form: form
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+      keeplogged: "1"
+      login: "Login"
+    error:
+      - selector: span.warning
+    test:
+      path: /torrents.php
+
+  ratio:
+    text: "-1"
+
+  search:
+    path: /torrents.php
+    inputs:
+      searchtext: "{{ .Query.Keywords }}"
+      order_by: "time"
+      order_way: "desc"
+      action: "advanced"
+
+    rows:
+      selector: table#torrent_table > tbody > tr.torrent
+    fields:
+      title:
+        selector: a[data-src]
+        attribute: data-src
+        filters:
+          - name: regexp
+            args: "(.+?)(\\.[\\d\\w]{3,4})?$"
+      description:
+        selector: div.tags
+      category:
+        selector: div.tags
+        case:
+          a[href="torrents.php?action=basic&taglist=hd"]: "2"
+          a[href="torrents.php?action=basic&taglist=sd"]: "3"
+          a:contains("4320p"): "2"
+          a:contains("2160p"): "2"
+          a:contains("1440p"): "2"
+          a:contains("1080p"): "2"
+          a:contains("720p"): "2"
+          a:contains("480p"): "3"
+          a:contains("360p"): "3"
+          a:contains("240p"): "3"
+#          "*": "1" # sometimes ovverrides an already matched category
+      comments:
+        selector: a[data-src]
+        attribute: href
+      download:
+        selector: a[href^="torrents.php?action=download&id="]
+        attribute: href
+      files:
+        selector: td > div:contains("Files:")
+        filters:
+          - name: regexp
+            args: "(\\d+)"
+      size:
+        selector: a[data-filesize]
+        attribute: data-filesize
+      seeders:
+        selector: td:nth-last-child(2)
+      leechers:
+        selector: td:nth-last-child(1)
+      date:
+        selector: span.time
+        attribute: title
+      grabs:
+        selector: td:nth-last-child(3)
+      downloadvolumefactor:
+        case:
+          img[alt="Freeleech"]: "0"
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "*": "1"

--- a/definitions/worldofp2p.yml
+++ b/definitions/worldofp2p.yml
@@ -134,6 +134,7 @@
       downloadvolumefactor:
         case:
           a.info:contains("Free"): "0"
+          img[src*="/free.png"]: "0"
           "*": "1"
       uploadvolumefactor:
         case:

--- a/definitions/worldofp2p.yml
+++ b/definitions/worldofp2p.yml
@@ -1,0 +1,140 @@
+---
+  site: worldofp2p
+  name: WorldOfP2P
+  description: "A general tracker"
+  language: en-us
+  links:
+    - https://worldofp2p.net
+
+  caps:
+    categories:
+      44: TV/Anime # Anime
+      22: PC # Applications
+      43: Audio/Audiobook # Audio Books
+      27: Books # Ebook
+      4:  PC/Games # Games
+      40: Other/Misc # Miscellaneous
+      19: Movies # Movies
+      6:  Audio # Music
+      31: PC/Phone-Other # Portable
+      7:  TV # TV
+      9:  TV/Anime  # Anime
+      15: PC/0day # Apps-Linux
+      16: PC/Mac # Apps-Macintosh
+      1: PC/0day # Apps-Misc
+      17: PC/Phone-Other # Apps-Mobile
+      49: Audio # Audio Tracks
+      51: Audio/Audiobook # AudioBook
+      50: Books # Ebooks
+      23: Console # Games-Mixed
+      32: Other # Games-Packs
+      2: PC/Games # Games-PC
+      12: PC/Games # Games-PC Rips
+      20: Console/Other # Games-PS1
+      8: Console/Other # Games-PS2
+      21: Console/PS3 # Games-PS3
+      22: Console/PS4 # Games-PS4
+      7: Console/PSP # Games-PSP
+      14: Console/Wii # Games-Wii
+      44: Console/Xbox360 # Games-Xbox 360
+      45: Console/Xbox # Games-Xbox One
+      43: Console/Xbox # Gamex-Xbox
+      30: Movies/HD # Movies-1080p
+      24: Movies/3D # Movies-3D
+      53: Movies/SD # Movies-480p
+      52: Movies/SD # Movies-576p
+      25: Movies/HD # Movies-720p
+      11: Movies/BluRay # Movies-Bluray
+      26: Movies/HD # Movies-BRRip
+      27: Movies/SD # Movies-Camera
+      10: Movies/DVD # Movies-DVDR
+      28: Movies/Other # Movies-Oldies
+      31: Movies/Other # Movies-Packs
+      33: Movies/Other # Movies-Sport
+      29: Movies/WEBDL # Movies-Web/DL
+      3: Movies/SD # Movies-XviD
+      13: Audio/Lossless # Music-Flac
+      4: Audio/MP3 # Music-MP3
+      18: Audio # Music-Packs
+      19: Audio/Video # Music-Videos
+      38: TV/HD # TV-Bluray
+      35: TV/SD # TV-DVDR
+      36: TV/SD # TV-DVDRip
+      37: TV/HD # TV-HD-x264
+      41: TV # TV-Packs
+      39: TV/SD # TV-SD-x264
+      42: TV/WEB-DL # TV-Web/DL
+      5:  TV/SD # TV-XviD
+      46: XXX # xXx-HD
+      47: XXX/Imageset # xXx-Images
+      48: XXX/Packs # xXx-Packs
+      6: XXX/XviD # xXx-XviD
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: /takelogin.php
+    method: post
+    form: form
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+      login: "Login"
+    error:
+      - selector: td.stdmsg2
+    test:
+      path: /usercp.php?action=default
+
+  ratio:
+    path: /usercp.php?action=default
+    selector: div#sts_tex1 > span.colorblue > span
+
+  search:
+    path: /browse.php
+    inputs:
+      $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
+      search: "{{ .Query.Keywords }}"
+      incldead: "1"
+      searchin: "title"
+
+    rows:
+      selector: div#browse > form > div > table.browsewidth100 > tbody > tr:has(a[href^="download.php?torrent="])
+    fields:
+      title:
+        selector: a[href^="details.php?id="]
+      category:
+        selector: a[href^="browse.php?cat="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: cat
+      comments:
+        selector: a[href^="details.php?id="]
+        attribute: href
+      download:
+        selector: a[href^="download.php?torrent="]
+        attribute: href
+      files:
+        selector: td:nth-child(5)
+      size:
+        selector: td:nth-child(8)
+      seeders:
+        selector: td:nth-child(10)
+      leechers:
+        selector: td:nth-child(11)
+      date:
+        selector: td:nth-child(7)
+      grabs:
+        selector: a[href^="snatches.php?id="]
+        filters:
+          - name: regexp
+            args: "(\\d+)"
+      downloadvolumefactor:
+        case:
+          a.info:contains("Free"): "0"
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "*": "1"

--- a/indexer/runner.go
+++ b/indexer/runner.go
@@ -602,7 +602,7 @@ func (r *Runner) resolveQuery(query torznab.Query) (torznab.Query, error) {
 
 	// convert show identifiers to season parameter
 	switch {
-	case query.TVDBID != "":
+	case query.TVDBID != "" && query.TVDBID != "0":
 		show, err = tvmaze.DefaultClient.GetShowWithTVDBID(query.TVDBID)
 		query.TVDBID = "0"
 	case query.TVMazeID != "":

--- a/torrentpotato/server.go
+++ b/torrentpotato/server.go
@@ -46,7 +46,7 @@ func Output(w http.ResponseWriter, items []torznab.ResultItem) {
 			DetailsURL:  item.Comments,
 			DownloadURL: item.Link,
 			Type:        "movie",
-			Size:        int(item.Size / 1024),
+			Size:        int(item.Size / 1024 / 1024),
 			Leechers:    item.Peers - item.Seeders,
 			Seeders:     item.Seeders,
 		})


### PR DESCRIPTION
For a new indexer, please follow this checklist:

- [X] Run `cardigann test definitions/trackername.yml` and include the output here:

```
→ Testing 1 definition(s) (1.9.3/windows/amd64)
→ Testing indexer worldofp2p at https://worldofp2p.net
  Testing required config is available SUCCESS V in 1.5002ms
  Testing login with valid credentials SUCCESS V in 1.1676483s
  Testing search mode "search" SUCCESS V in 5.6902225s
  Testing search mode "tv-search" SUCCESS V in 4.9361268s
  Testing empty results are handled SUCCESS V in 1.2476584s
  Testing ratio SUCCESS V in 962.1222ms
→ Indexer worldofp2p is OK
``` 

- [X] Make sure to add the indexer to the list in the README