### PR TITLE
Add Transmithe.net tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Torrentbytes
 * TorrentDay
 * Torrentleech
+* Transmithe.Net
 
 I'm happy to add new trackers, please either open a new issue, or a pull request with whatever details you have for the tracker.
 

--- a/definitions/transmithenet.yml
+++ b/definitions/transmithenet.yml
@@ -1,0 +1,98 @@
+﻿---
+  site: transmithenet
+  name: Transmithe.net
+  description: "A TV tracker"
+  language: en-us
+  links:
+    - https://transmithe.net
+
+  caps:
+    categories:
+      1: TV
+      2: TV/HD
+      3: TV/SD
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: /login.php
+    method: post
+    form: form
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+      keeplogged: "1"
+      login: "Login"
+    error:
+      - selector: span.warning
+    test:
+      path: /torrents.php
+
+  ratio:
+    text: "-1"
+
+  search:
+    path: /torrents.php
+    inputs:
+      searchtext: "{{ .Query.Keywords }}"
+      order_by: "time"
+      order_way: "desc"
+      action: "advanced"
+
+    rows:
+      selector: table#torrent_table > tbody > tr.torrent
+    fields:
+      title:
+        selector: a[data-src]
+        attribute: data-src
+        filters:
+          - name: regexp
+            args: "(.+?)(\\.[\\d\\w]{3,4})?$"
+      description:
+        selector: div.tags
+      category:
+        selector: div.tags
+        case:
+          a[href="torrents.php?action=basic&taglist=hd"]: "2"
+          a[href="torrents.php?action=basic&taglist=sd"]: "3"
+          a:contains("4320p"): "2"
+          a:contains("2160p"): "2"
+          a:contains("1440p"): "2"
+          a:contains("1080p"): "2"
+          a:contains("720p"): "2"
+          a:contains("480p"): "3"
+          a:contains("360p"): "3"
+          a:contains("240p"): "3"
+#          "*": "1" # sometimes ovverrides an already matched category
+      comments:
+        selector: a[data-src]
+        attribute: href
+      download:
+        selector: a[href^="torrents.php?action=download&id="]
+        attribute: href
+      files:
+        selector: td > div:contains("Files:")
+        filters:
+          - name: regexp
+            args: "(\\d+)"
+      size:
+        selector: a[data-filesize]
+        attribute: data-filesize
+      seeders:
+        selector: td:nth-last-child(2)
+      leechers:
+        selector: td:nth-last-child(1)
+      date:
+        selector: span.time
+        attribute: title
+      grabs:
+        selector: td:nth-last-child(3)
+      downloadvolumefactor:
+        case:
+          img[alt="Freeleech"]: "0"
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "*": "1"


### PR DESCRIPTION
Fix #112

- [X] Run `cardigann test definitions/trackername.yml` and include the output here:

```
→ Testing 1 definition(s) (1.9.3/windows/amd64)
→ Testing indexer transmithenet at https://transmithe.net
  Testing required config is available SUCCESS V in 1.0001ms
  Testing login with valid credentials SUCCESS V in 1.1131413s
  Testing search mode "search" SUCCESS V in 4.5110728s
  Testing search mode "tv-search" SUCCESS V in 4.0885192s
  Testing empty results are handled SUCCESS V in 917.6165ms
  Testing ratio SUCCESS V in 0s
→ Indexer transmithenet is OK
``` 

- [X] Make sure to add the indexer to the list in the README

