### PR TITLE
fix indexer error when tvdb is 0

### DIFF
--- a/indexer/runner.go
+++ b/indexer/runner.go
@@ -602,7 +602,7 @@ func (r *Runner) resolveQuery(query torznab.Query) (torznab.Query, error) {
 
 	// convert show identifiers to season parameter
 	switch {
-	case query.TVDBID != "":
+	case query.TVDBID != "" && query.TVDBID != "0":
 		show, err = tvmaze.DefaultClient.GetShowWithTVDBID(query.TVDBID)
 		query.TVDBID = "0"
 	case query.TVMazeID != "":


### PR DESCRIPTION
Sonarr(nzbdrone) will call cardigann API with tvdb=0, it returns an error back
```xml
<error>
<code>900</code>
<description>
json: cannot unmarshal number into Go value of type string
</description>
</error>
```
Digging in the issue, looks like http client in tvmaze/client.go tries to call tvmaze ( http://api.tvmaze.com/lookup/shows?thetvdb=0 ), which returns:

```javascript
{
"name": "Bad Request",
"message": "",
"code": 0,
"status": 400
}
```

Although probably adding error handling would be a better solution, I felt that with tvdb=0 the client should not even make the call in the first place.

