### PR TITLE
Add replace function to template

### DIFF
--- a/indexer/runner.go
+++ b/indexer/runner.go
@@ -151,7 +151,10 @@ func (r *Runner) checkHasConfig() error {
 }
 
 func (r *Runner) applyTemplate(name, tpl string, ctx interface{}) (string, error) {
-	tmpl, err := template.New(name).Parse(tpl)
+	funcMap := template.FuncMap {
+		"replace": strings.Replace,
+	}
+	tmpl, err := template.New(name).Funcs(funcMap).Parse(tpl)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Add `replace` function to templates.

Example usage: `'{{replace .Keywords " " "*" -1}}'`