### PR TITLE
Update iptorrents.yml

### DIFF
--- a/definitions/iptorrents.yml
+++ b/definitions/iptorrents.yml
@@ -69,7 +69,7 @@
     inputs:
       cookie: "{{ .Config.cookie }}"
     test:
-      path: /my.php
+      path: /settings.php
 
   ratio:
     path: /indexipt.php


### PR DESCRIPTION
URL changed on IPT. A redirect is in place, but results in login error on Cardigann.