### PR TITLE
Remove "/" from title before using as filename.

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -394,7 +394,8 @@ func (h *handler) rewriteLinks(r *http.Request, items []torznab.ResultItem) ([]t
 			return nil, err
 		}
 
-		items[idx].Link = fmt.Sprintf("%s/%s/%s.torrent", baseURL.String(), te, url.QueryEscape(item.Title))
+		filename := strings.Replace(item.Title, "/", "-", -1)
+		items[idx].Link = fmt.Sprintf("%s/%s/%s.torrent", baseURL.String(), te, url.QueryEscape(filename))
 	}
 
 	return items, nil


### PR DESCRIPTION
It's not safe to assume the title is a filename because it may contain characters not valid for a filename. Removing / prevents a valid title to break the "/download/" route, but further sanitization is required.