### PR TITLE
add categories from Jackett#1047

### DIFF
--- a/definitions/torrentz2.yml
+++ b/definitions/torrentz2.yml
@@ -12,6 +12,23 @@
       "video tv": TV
       "video": Movies
       "video movie hd": Movies/HD
+      "adult": XXX
+      "ebook comics": Books/Comics
+      "ebook": Books/Ebook
+      "ebook tutorial": Books/Technical
+      "ebook magazine": Books/Magazines
+      "audio music mp3": Audio/MP3
+      "ebook audio book": Audio/Audiobook
+      "audio music lossless": Audio/Lossless
+      "application": PC/0day
+      "game": PC/Games
+      "game xbox": Console/Xbox
+      "adult milf": XXX
+      "adult hairy": XXX
+      "adult anal": XXX
+      "adult blowjobs": XXX
+      "game pc": PC/Games
+      "audio": Audio
 
     modes:
       search: [q]


### PR DESCRIPTION
I tried adding append filter with &dn={{ .Result.title }}.torrent, like Jackett definition, so added torrent has name before downloading metadata, but it didn't work in cardigann, I guess cardigann doesn't support template in filters args.
