### PR TITLE
Update torrentday.yml

### DIFF
--- a/definitions/torrentday.yml
+++ b/definitions/torrentday.yml
@@ -87,13 +87,13 @@
         selector: td:nth-child(2) > a
         attribute: href
       comments:
-        selector: td:nth-child(4) > a
+        selector: td:nth-child(5) > a
         attribute: href
       download:
         selector: td:nth-child(3) > a
         attribute: href
       size:
-        selector: td:nth-child(5)
+        selector: td:nth-child(6)
       date:
         selector: td:nth-child(2) .t_ctime
         filters:
@@ -102,6 +102,6 @@
           - name: split
             args: [ " by ", 0 ]
       seeders:
-        selector: td:nth-child(6)
-      leechers:
         selector: td:nth-child(7)
+      leechers:
+        selector: td:nth-child(8)


### PR DESCRIPTION
Torrentday have added a "bookmark" link column to the results table, which has shifted everything to the right of it by one.

![example](http://i.imgur.com/KAvp5h6.png)