### PR TITLE
Fix bug with alpharatio category parsing, closes #394

### DIFF
--- a/definitions/alpharatio.yml
+++ b/definitions/alpharatio.yml
@@ -60,7 +60,7 @@
         attribute: href
         filters:
           - name: regexp
-            args: "filter_cat\\[\\d+\\]=(\\d+)"
+            args: "filter_cat\\[(\\d+)\\]=1"
       title:
         selector: td.big_info .group_info > a:nth-child(2)
       details:


### PR DESCRIPTION
Category parameter changed to `filter_cat[7]=1` where 7 is the category name.