### PR TITLE
Add metal-tracker.com Indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Transmithe.Net
 * Tspate
 * YggTorrent
+* Metal-tracker.com
 
 ### Dead
 * AlphaReign

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * HD-Torrents
 * Immortalseed
 * IPTorrents
+* Metal-tracker.com
 * MoreThanTV
 * MyAnonamouse
 * MySpleen
@@ -178,7 +179,6 @@ Cardigann simply provides a format for describing how to log into and scrape the
 * Transmithe.Net
 * Tspate
 * YggTorrent
-* Metal-tracker.com
 
 ### Dead
 * AlphaReign

--- a/definitions/metaltracker.yml
+++ b/definitions/metaltracker.yml
@@ -1,0 +1,70 @@
+﻿---
+  site: metaltracker
+  name: Metal Tracker
+  description: "Metal Tracker is a Semi-Private site dedicated to HEAVY METAL MUSIC. This definition is for the English site."
+  language: en-us
+  type: semi-private
+  encoding: UTF-8
+  links:
+    - http://en.metal-tracker.com/
+
+  caps:
+    categories:
+      "Books": Audio/Audiobook
+      "Video": Audio/Video
+      "Music": Audio/MP3
+
+    modes:
+      search: [q]
+      music-search: [q, album, artist, label, year]
+
+  login:
+    path: /user/login.html
+    method: form
+    form: form[action="/user/login.html"]
+    inputs:
+      UserLogin[username]: "{{ .Config.username }}"
+      UserLogin[password]: "{{ .Config.password }}"
+    error:
+      - selector: div.errorSummary
+        message:
+          selector: div.errorSummary ul li
+    test:
+      path: /torrents/search.html
+      selector: li li:has(a[href="/user/logout.html"])
+
+  search:
+    path: /torrents/search.html
+    method: post
+    inputs:
+      "SearchTorrentsForm[nameTorrent]": "{{ .Query.Keywords }}"
+      go-search: "Search"
+    rows:
+      selector: .smallalbum
+    fields:
+      title:
+        selector: a h3
+      details:
+        selector: .thumb a
+        attribute: href
+      download:
+        selector: .center a[href^="/torrents/download/id/"]
+        attribute: href
+      seeders:
+        selector: .center font:nth-of-type(1)
+      leechers:
+        selector: .center font:nth-of-type(2)
+      downloadvolumefactor:
+        text: "0"
+      uploadvolumefactor:
+        text: "1"
+      date:
+        text: "today"
+      category:
+        filters:
+          - name: regexp
+            args: ".*Type: ([A-Z][a-z]+).*"
+      size:
+        filters:
+          - name: regexp
+            args: "Size:\\s+([\\w\\d\\.,]+ \\w\\w)"


### PR DESCRIPTION
Inspired by Jackett and comments in the related issue. 
Date has been set to "today" which appears as "in an hour".
Not yet tested with headphones...

- [ ] Run `cardigann test definitions/metaltracker.yml` 

```
→ Testing 1 definition(s) (1.9.10-6-g70a254b/linux/amd64)
→ Testing indexer metaltracker at http://en.metal-tracker.com/
  Testing required config is available SUCCESS ✓ in 2.164954ms
  Testing login with valid credentials SUCCESS ✓ in 1.767531041s
  Testing search mode "search" SUCCESS ✓ in 2.650540518s
  Testing search mode "music-search" SUCCESS ✓ in 2.430225372s
  Testing empty results are handled SUCCESS ✓ in 865.36451ms
  Testing ratio SUCCESS ✓ in 174.579µs
→ Indexer metaltracker is OK
``` 

- [ ] Added to the README

It may close #375