### PR TITLE
Fix passphrase auth with non-root prefixes

### DIFF
--- a/web/src/Login.js
+++ b/web/src/Login.js
@@ -4,7 +4,7 @@ import xhrUrl from './xhr';
 
 class Login extends Component {
   static defaultProps = {
-    authUrl: "/xhr/auth",
+    authUrl: "./xhr/auth",
     onAuthenticate: () => {},
   }
   state = {


### PR DESCRIPTION
The prefix path (e.g. `/cardigann/`) isn't respected when passphrases are used. The absolute URL of `/xhr/..` is used instead of the relative path `./xhr/..`