### PR TITLE
Fix size units in yggtorrent results

### DIFF
--- a/definitions/yggtorrent.yml
+++ b/definitions/yggtorrent.yml
@@ -189,13 +189,13 @@
         selector: td:nth-child(6)
         filters:
           - name: replace
-            args: [ "KB", "kib"]
+            args: [ "Ko", "kib"]
           - name: replace
-            args: [ "MB", "mib"]
+            args: [ "Mo", "mib"]
           - name: replace
-            args: [ "GB", "gib"]
+            args: [ "Go", "gib"]
           - name: replace
-            args: [ "TB", "tib"]
+            args: [ "To", "tib"]
       seeders:
         selector: td:nth-child(8)
       leechers:


### PR DESCRIPTION
This PR fixes the parsing of the size field in results after a change on the yggtorrent side...

→ Testing 1 definition(s) (1.10.1-9-g1501db7/linux/amd64)
→ Testing indexer yggtorrent at https://yggtorrent.is
  Testing required config is available SUCCESS ✓ in 2.871409ms
  Testing login with valid credentials SUCCESS ✓ in 1.272973104s
  Testing search mode "search" SUCCESS ✓ in 1.684820174s
  Testing search mode "tv-search" SUCCESS ✓ in 2.005779229s
  Testing search mode "movie-search" SUCCESS ✓ in 1.566366819s
  Testing empty results are handled SUCCESS ✓ in 363.027111ms
  Testing ratio SUCCESS ✓ in 40.743µs
→ Indexer yggtorrent is OK

Should fix #434 