### PR TITLE
Updated TorrentDay definition

### DIFF
--- a/definitions/torrentday.yml
+++ b/definitions/torrentday.yml
@@ -70,10 +70,10 @@
     inputs:
       $raw: "{{range .Categories}}{{.}}&{{end}}q={{ .Query.Keywords }}"
     rows:
-      selector: table#torrentTable > tbody > tr:nth-child(n+2):has(td.t_label)
+      selector: table#torrentTable > tbody > tr:nth-child(n+2):has(td.torrentNameInfo)
     fields:
       category:
-        selector: td.t_label > a
+        selector: td:nth-child(1) > a
         attribute: href
         filters:
           - name: regexp

--- a/indexer/runner.go
+++ b/indexer/runner.go
@@ -205,8 +205,12 @@ func (r *Runner) testURLWorks(u string) bool {
 		r.logger.WithError(err).Warn("URL check failed")
 		return false
 	} else if r.browser.StatusCode() != http.StatusOK {
-		r.logger.Warn("URL returned non-ok status")
-		return false
+		if r.browser.Title() == "Just a moment..." {
+			r.logger.Warn("Found cloudflare check, assuming OK")
+		} else {
+			r.logger.Warn("URL returned non-ok status")
+			return false
+		}
 	}
 
 	return true


### PR DESCRIPTION
* Result table: `td.t_label` was changed to `td.torrentNameInfo`
* Made label selector use `nth-child` to be consistent with others
* Added workaround for Cloudflare browser check